### PR TITLE
TDD Slack Gateway

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -14,7 +14,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
     public class CryptoTechReminderSystemTests
     {
         private FluentSimulator _fluentSimulator;
-        private SlackGateway _slackGateway;
+        private IMessageSender _slackGateway;
         private RemindUser _remindUser;
         
         public class SlackPostMessageResponse

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -6,7 +6,7 @@ using CryptoTechReminderSystem.Gateway;
 using CryptoTechReminderSystem.UseCase;
 using FluentSim;
 using Newtonsoft.Json;
-using static CryptoTechReminderSystem.Gateway.MessageSender;
+using static CryptoTechReminderSystem.Gateway.SlackGateway;
 using static Newtonsoft.Json.JsonConvert;
 
 namespace CryptoTechReminderSystem.AcceptanceTest
@@ -14,7 +14,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
     public class CryptoTechReminderSystemTests
     {
         private FluentSimulator _fluentSimulator;
-        private MessageSender _messageSender;
+        private SlackGateway _slackGateway;
         private RemindUser _remindUser;
         
         public class SlackPostMessageResponse
@@ -37,11 +37,12 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             _fluentSimulator.Post("/api/chat.postMessage").Responds(slackPostMessageResponse);
         }
 
-        private void WhenWeRemindUser(string userId)
+        private void WhenWeRemindUser(string channel, string text)
         {
             _remindUser.Execute(new RemindUserRequest
             {
-                UserId = userId
+                Channel = channel,
+                Text = text
             });
         }
 
@@ -55,8 +56,8 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             receivedRequest.Headers["Authorization"].Should().Be(
                 "Bearer xxxx-xxxxxxxxx-xxxx"
             );
-            GetRequest(receivedRequest).channel.Should().Be(userId);
-            GetRequest(receivedRequest).text.Should().Be(
+            GetRequest(receivedRequest).Channel.Should().Be(userId);
+            GetRequest(receivedRequest).Text.Should().Be(
                 "Please make sure your timesheet is submitted by 13:30 on Friday."
             );
         }
@@ -67,11 +68,11 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             _fluentSimulator = new FluentSimulator(
                 "http://localhost:8009/"
             );
-            _messageSender = new MessageSender(
+            _slackGateway = new SlackGateway(
                 "http://localhost:8009/",
                 "xxxx-xxxxxxxxx-xxxx"
             );
-            _remindUser = new RemindUser(_messageSender);
+            _remindUser = new RemindUser(_slackGateway);
             _fluentSimulator.Start();
         }
 
@@ -86,7 +87,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         {
             GivenSlackRespondsWithOk();
 
-            WhenWeRemindUser("U172L982");
+            WhenWeRemindUser("U172L982", "Please make sure your timesheet is submitted by 13:30 on Friday.");
 
             ThenMessageHasBeenPostedToSlack("U172L982");
         }

--- a/CryptoTechReminderSystem.Main/Program.cs
+++ b/CryptoTechReminderSystem.Main/Program.cs
@@ -13,7 +13,7 @@ namespace CryptoTechReminderSystem.Main
         static void Main(string[] args)
         {    
             DotEnv.Config();
-            var remindUser = new RemindUser(new MessageSender("https://slack.com/", Environment.GetEnvironmentVariable("SLACK_TOKEN")));
+            var remindUser = new RemindUser(new SlackGateway("https://slack.com/", Environment.GetEnvironmentVariable("SLACK_TOKEN")));
             
             IList<string> idsList = new List<string>()
             {
@@ -29,7 +29,8 @@ namespace CryptoTechReminderSystem.Main
             {
                 remindUser.Execute(new RemindUserRequest
                 {
-                    UserId = id
+                    Channel = id,
+                    Text = "Please make sure your timesheet is submitted by 13:30 on Friday."
                 });
             }
         }

--- a/CryptoTechReminderSystem.Test/CryptoTechReminderSystem.Test.csproj
+++ b/CryptoTechReminderSystem.Test/CryptoTechReminderSystem.Test.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="FluentAssertions" Version="5.6.0" />
+        <PackageReference Include="FluentSimulator" Version="1.0.33" />
         <PackageReference Include="nunit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.11.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />

--- a/CryptoTechReminderSystem.Test/RemindUserTests.cs
+++ b/CryptoTechReminderSystem.Test/RemindUserTests.cs
@@ -9,7 +9,7 @@ namespace CryptoTechReminderSystem.Test
 {
     public class RemindUserTests
     {
-        class SlackGatewaySpy : ISlackGateway
+        class SlackGatewaySpy : IMessageSender
         {
             public Message Message;
         

--- a/CryptoTechReminderSystem.Test/RemindUserTests.cs
+++ b/CryptoTechReminderSystem.Test/RemindUserTests.cs
@@ -9,7 +9,7 @@ namespace CryptoTechReminderSystem.Test
 {
     public class RemindUserTests
     {
-        class MessageSenderSpy : IMessageSender
+        class SlackGatewaySpy : ISlackGateway
         {
             public Message Message;
         
@@ -22,29 +22,31 @@ namespace CryptoTechReminderSystem.Test
         [Test]
         public void CanRemindUser()
         {
-            var spy = new MessageSenderSpy();
+            var spy = new SlackGatewaySpy();
             var remindUser = new RemindUser(spy);
             
             remindUser.Execute(new RemindUserRequest
             {
-                UserId = "U120123D"
+                Channel = "U120123D",
+                Text = "Please make sure your timesheet is submitted by 13:30 on Friday."
             });
             
-            spy.Message.UserId.Should().Be("U120123D");
+            spy.Message.Channel.Should().Be("U120123D");
         }
         
         [Test]
         public void CanRemindUser2()
         {
-            var spy = new MessageSenderSpy();
+            var spy = new SlackGatewaySpy();
             var remindUser = new RemindUser(spy);
             
             remindUser.Execute(new RemindUserRequest
             {
-                UserId = "U87219HAW"
+                Channel = "U87219HAW",
+                Text = "Please make sure your timesheet is submitted by 13:30 on Friday."
             });
             
-            spy.Message.UserId.Should().Be("U87219HAW");
+            spy.Message.Channel.Should().Be("U87219HAW");
         }
     }
 }

--- a/CryptoTechReminderSystem.Test/SlackGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/SlackGatewayTests.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using CryptoTechReminderSystem.DomainObject;
+using CryptoTechReminderSystem.Gateway;
+using FluentAssertions;
+using FluentSim;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using static Newtonsoft.Json.JsonConvert;
+
+namespace CryptoTechReminderSystem.Test
+{
+    public class SlackGatewayTests
+    {
+        private FluentSimulator _fluentSimulator;
+        
+        public class SlackPostMessageResponse
+        {
+            [JsonProperty("ok")] public bool IsOk;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            _fluentSimulator = new FluentSimulator("http://localhost:8011/");
+            
+            var slackPostMessageResponse = new SlackPostMessageResponse
+            {
+                IsOk = true
+            };
+            
+            _fluentSimulator.Post("/api/chat.postMessage").Responds(slackPostMessageResponse);
+
+            _fluentSimulator.Start();
+        }
+        
+        [TearDown]
+        public void TearDown()
+        {
+            _fluentSimulator.Stop();
+        }
+        
+        [Test]
+        public void CanSendAPostMessageRequest()
+        {
+            var messageSender = new SlackGateway("http://localhost:8011/", "xxxx-xxxxxxxxx-xxxx");
+            
+            messageSender.Send(new Message());
+            
+            var receivedRequest = _fluentSimulator.ReceivedRequests.First();
+                
+            receivedRequest.Url.Should().Be("http://localhost:8011/api/chat.postMessage");
+        }
+        
+        [Test]
+        public void CanSendAPostMessageRequestWithAToken()
+        {
+            var messageSender = new SlackGateway("http://localhost:8011/", "xxxx-xxxxxxxxx-xxxx");
+            
+            messageSender.Send(new Message());
+            
+            var receivedRequest = _fluentSimulator.ReceivedRequests.First();
+                
+            receivedRequest.Url.Should().Be("http://localhost:8011/api/chat.postMessage");
+        }
+        
+        [Test]
+        public void CanSendAMessageToAUser()
+        {
+            var messageSender = new SlackGateway("http://localhost:8011/", "xxxx-xxxxxxxxx-xxxx");
+            var message = new Message()
+            {
+                Channel = "U98DL811"
+            };
+            messageSender.Send(message);
+            
+            var receivedRequest = _fluentSimulator.ReceivedRequests.First();
+            
+            receivedRequest.Headers["Authorization"].Should().Be(
+                "Bearer xxxx-xxxxxxxxx-xxxx"
+            );
+        }
+        
+        [Test]
+        public void CanSendAMessageToAUserWithAText()
+        {
+            var messageSender = new SlackGateway("http://localhost:8011/", "xxxx-xxxxxxxxx-xxxx");
+            var message = new Message()
+            {
+                Channel = "U98DL811",
+                Text = "Please make sure your timesheet is submitted by 13:30 on Friday."
+            };
+            messageSender.Send(message);
+            
+            var receivedRequest = _fluentSimulator.ReceivedRequests.First();
+                
+            DeserializeObject<PostMessageRequest>(receivedRequest.RequestBody).Text.Should().Be("Please make sure your timesheet is submitted by 13:30 on Friday.");
+        }
+    }
+}

--- a/CryptoTechReminderSystem.Test/SlackGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/SlackGatewayTests.cs
@@ -60,7 +60,9 @@ namespace CryptoTechReminderSystem.Test
             
             var receivedRequest = _fluentSimulator.ReceivedRequests.First();
                 
-            receivedRequest.Url.Should().Be("http://localhost:8011/api/chat.postMessage");
+            receivedRequest.Headers["Authorization"].Should().Be(
+                "Bearer xxxx-xxxxxxxxx-xxxx"
+            );
         }
         
         [Test]
@@ -75,9 +77,8 @@ namespace CryptoTechReminderSystem.Test
             
             var receivedRequest = _fluentSimulator.ReceivedRequests.First();
             
-            receivedRequest.Headers["Authorization"].Should().Be(
-                "Bearer xxxx-xxxxxxxxx-xxxx"
-            );
+            DeserializeObject<PostMessageRequest>(receivedRequest.RequestBody).Channel.Should().Be("U98DL811");
+
         }
         
         [Test]

--- a/CryptoTechReminderSystem/Boundary/RemindUserRequest.cs
+++ b/CryptoTechReminderSystem/Boundary/RemindUserRequest.cs
@@ -2,6 +2,7 @@ namespace CryptoTechReminderSystem.Boundary
 {
     public class RemindUserRequest
     {
-        public string UserId { get; set; }
+        public string Channel { get; set; }
+        public string Text { get; set; }
     }
 }

--- a/CryptoTechReminderSystem/DomainObject/Message.cs
+++ b/CryptoTechReminderSystem/DomainObject/Message.cs
@@ -2,6 +2,7 @@ namespace CryptoTechReminderSystem.DomainObject
 {
     public class Message
     {
-        public string UserId { get; set; }
+        public string Channel { get; set; }
+        public string Text { get; set; }
     }
 }

--- a/CryptoTechReminderSystem/Gateway/IMessageSender.cs
+++ b/CryptoTechReminderSystem/Gateway/IMessageSender.cs
@@ -2,7 +2,7 @@ using CryptoTechReminderSystem.DomainObject;
 
 namespace CryptoTechReminderSystem.UseCase
 {
-    public interface ISlackGateway
+    public interface IMessageSender
     {
         void Send(Message message);
     }

--- a/CryptoTechReminderSystem/Gateway/ISlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/ISlackGateway.cs
@@ -1,0 +1,9 @@
+using CryptoTechReminderSystem.DomainObject;
+
+namespace CryptoTechReminderSystem.UseCase
+{
+    public interface ISlackGateway
+    {
+        void Send(Message message);
+    }
+}

--- a/CryptoTechReminderSystem/Gateway/SlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/SlackGateway.cs
@@ -1,56 +1,47 @@
 using System;
-using CryptoTechReminderSystem.DomainObject;
-using CryptoTechReminderSystem.UseCase;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
+using CryptoTechReminderSystem.DomainObject;
+using CryptoTechReminderSystem.UseCase;
 using Newtonsoft.Json;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public class MessageSender : IMessageSender
+    public class SlackGateway : IMessageSender
     {
-        public class PostMessageRequest
-        {
-            public string channel{ get; set; }
-            public string text { get; set; }
-            public string icon_emoji { get; set; }
-            public bool as_user { get; set; }
-            
-        }
-        
         private readonly HttpClient _client;
-        private string _token;
+        private readonly string _token;
 
-        public MessageSender(string address, string token)
+        public SlackGateway(string address, string token)
         {
-            _client = new HttpClient {BaseAddress = new Uri(address)};
+            _client = new HttpClient
+            {
+                BaseAddress = new Uri(address)
+            };
             _token = token;
         }
 
         public void Send(Message message)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-
-
-            var request = JsonConvert.SerializeObject(new PostMessageRequest
-            {
-                channel = message.UserId,
-                text = "Please make sure your timesheet is submitted by 13:30 on Friday."
-            });
-            var content = new StringContent(request, Encoding.UTF8,
-                "application/json");
+            var request = JsonConvert.SerializeObject(new PostMessageRequest());
+            var content = new StringContent(request, Encoding.UTF8, "application/json");
             var result = PostChatMessage(content).Result;
-            Console.WriteLine(result);
         }
-
+        
         private async Task<object> PostChatMessage(StringContent content)
         {
-            var requestUrl = "/api/chat.postMessage";
-            var response = await _client.PostAsync(requestUrl, content);
-            var result = await response.Content.ReadAsStringAsync();
-            return result;
+            var requestPath = "/api/chat.postMessage";
+            var response = await _client.PostAsync(requestPath, content);
+            return await response.Content.ReadAsStringAsync();;
         }
+    }
+
+    public class PostMessageRequest
+    {
+        public string channel { get; set; }
+        public string text { get; set; }
     }
 }

--- a/CryptoTechReminderSystem/Gateway/SlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/SlackGateway.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public class SlackGateway : ISlackGateway
+    public class SlackGateway : IMessageSender
     {
         private readonly HttpClient _client;
         private readonly string _token;

--- a/CryptoTechReminderSystem/Gateway/SlackGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/SlackGateway.cs
@@ -9,7 +9,7 @@ using Newtonsoft.Json;
 
 namespace CryptoTechReminderSystem.Gateway
 {
-    public class SlackGateway : IMessageSender
+    public class SlackGateway : ISlackGateway
     {
         private readonly HttpClient _client;
         private readonly string _token;
@@ -26,22 +26,31 @@ namespace CryptoTechReminderSystem.Gateway
         public void Send(Message message)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-            var request = JsonConvert.SerializeObject(new PostMessageRequest());
+            
+            var request = JsonConvert.SerializeObject(new PostMessageRequest
+            {
+                Channel = message.Channel,
+                Text = message.Text
+            });
             var content = new StringContent(request, Encoding.UTF8, "application/json");
             var result = PostChatMessage(content).Result;
+            Console.WriteLine(result);
         }
         
         private async Task<object> PostChatMessage(StringContent content)
         {
             var requestPath = "/api/chat.postMessage";
             var response = await _client.PostAsync(requestPath, content);
-            return await response.Content.ReadAsStringAsync();;
+            var result = await response.Content.ReadAsStringAsync();
+            return result;
         }
     }
 
     public class PostMessageRequest
     {
-        public string channel { get; set; }
-        public string text { get; set; }
+        [JsonProperty("channel")]
+        public string Channel { get; set; }
+        [JsonProperty("text")]
+        public string Text { get; set; }
     }
 }

--- a/CryptoTechReminderSystem/UseCase/RemindUser.cs
+++ b/CryptoTechReminderSystem/UseCase/RemindUser.cs
@@ -6,24 +6,20 @@ namespace CryptoTechReminderSystem.UseCase
 {
     public class RemindUser
     {
-        private readonly IMessageSender _messageSender;
+        private readonly ISlackGateway _slackGateway;
 
-        public RemindUser(IMessageSender messageSender)
+        public RemindUser(ISlackGateway slackGateway)
         {
-            _messageSender = messageSender;
+            _slackGateway = slackGateway;
         }
 
         public void Execute(RemindUserRequest remindUserRequest)
         {
-            _messageSender.Send(new Message
+            _slackGateway.Send(new Message
             {
-                UserId = remindUserRequest.UserId
+                Channel = remindUserRequest.Channel,
+                Text = remindUserRequest.Text
             });
         }
-    }
-
-    public interface IMessageSender
-    {
-        void Send(Message message);
     }
 }

--- a/CryptoTechReminderSystem/UseCase/RemindUser.cs
+++ b/CryptoTechReminderSystem/UseCase/RemindUser.cs
@@ -6,9 +6,9 @@ namespace CryptoTechReminderSystem.UseCase
 {
     public class RemindUser
     {
-        private readonly ISlackGateway _slackGateway;
+        private readonly IMessageSender _slackGateway;
 
-        public RemindUser(ISlackGateway slackGateway)
+        public RemindUser(IMessageSender slackGateway)
         {
             _slackGateway = slackGateway;
         }


### PR DESCRIPTION
- Renamed `MessageSender` to `SlackGateway`
- Renamed `IMessageSender` to `ISlackGateway` and moved to `Gateway` directory
- Added unit tests for `SlackGateway`
- Refactored so text is taken by `RemindUser` use case and to `Message` domain object
- Updated `Main` for changes to `SlackGateway`