### PR TITLE
Allow ENV variables to be set when docker image is run

### DIFF
--- a/CryptoTechReminderSystem.Main/Program.cs
+++ b/CryptoTechReminderSystem.Main/Program.cs
@@ -11,7 +11,7 @@ namespace CryptoTechReminderSystem.Main
     {
         static void Main(string[] args)
         {    
-            DotEnv.Config();
+            DotEnv.Config(false);
             
             var remindDeveloper = new SendReminder(
                 new SlackGateway(


### PR DESCRIPTION
Adding false when getting the .env file to allow the docker run to set it's own ENV variables. 