### PR TITLE
Implement starting and ending date for retrieving timesheets

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -73,8 +73,10 @@ namespace CryptoTechReminderSystem.AcceptanceTest
                     "../../../HarvestTimeEntriesExampleResponse.json"
                 )
             );
-            
-            _harvestApi.Get("/api/v2/time_entries").Responds(harvestGetTimeEntriesResponse);
+            _harvestApi.Get("/api/v2/time_entries")
+                .WithParameter("from", "2019-02-25")
+                .WithParameter("to", "2019-03-01")
+                .Responds(harvestGetTimeEntriesResponse);
             
             _slackApi.Start();
             _harvestApi.Start();

--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -96,12 +96,13 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         [Test]
         public void CanRemindLateDevelopersAtTenThirtyOnFriday()
         {                      
-            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway);
             var clock = new ClockStub(
                 new DateTimeOffset(
                     new DateTime(2019, 03, 01, 10, 30, 0)
                 )
             );
+            
+            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
 
             var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminder, clock);
 
@@ -142,12 +143,13 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             [TestCase(13, 15, 20)]
             public void CanRemindLateDevelopersEveryHalfHourUntilOneThirty(int hour, int minute, int expectedCount)
             {                      
-                var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway);
                 var clock = new ClockStub(
                     new DateTimeOffset(
                         new DateTime(2019, 03, 01, hour, minute, 0)
                     )
                 );
+                
+                var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
 
                 var remindLateDevelopers = new RemindLateDevelopers(getLateDevelopers, _sendReminder, clock);
 
@@ -164,13 +166,13 @@ namespace CryptoTechReminderSystem.AcceptanceTest
         [Test]
         public void CanRemindLearnTechChannelAtOneThirty()
         {
-            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway);
-            
             var clock = new ClockStub(
                 new DateTimeOffset(
                     new DateTime(2019, 03, 01, 13, 30, 0)
                 )
             );
+            
+            var getLateDevelopers = new GetLateDevelopers(_slackGateway, _harvestGateway, _harvestGateway, clock);
 
             var shameLateDevelopers = new ShameLateDevelopers(getLateDevelopers, _sendReminder, clock);
 

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -127,10 +127,9 @@ namespace CryptoTechReminderSystem.Test.Gateway
             }
 
             [Test]
-            [TestCase(456709345)]
-            [TestCase(636709355)]
-            [TestCase(636709356)]
-            public void CanGetATimeSheet(int expectedId)
+            [TestCase(1782975)]
+            [TestCase(1782974)]
+            public void CanGetATimeSheet(int expectedUserId)
             {
                 SetUpTimeSheetApiEndpoint("2019-04-08", "2019-04-12");
 
@@ -144,7 +143,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 
                 var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
 
-                response.Any(entry => entry.Id == expectedId).Should().BeTrue();
+                response.Any(entry => entry.UserId == expectedUserId).Should().BeTrue();
             }
 
             [Test]

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -38,58 +38,38 @@ namespace CryptoTechReminderSystem.Test.Gateway
             {
                 var json = $"{{  \"users\":[    {{      \"id\":{id},      \"first_name\":\"{firstName}\"" +
                            $",      \"last_name\":\"{lastName}\",      \"email\":\"{email}\"    }}  ]}}";
+                
                 _harvestApi.Get("/api/v2/users").Responds(json);
             }
-
+            
             [Test]
-            public void CanGetDeveloper()
+            public void CanGetDevelopersWithAuthentication()
             {
-                SetUpUsersApiEndpoint(
-                    "123",
-                    "Wen Ting",
-                    "Wang",
-                    "ting@email.com"
-                );
-
-                var response = _harvestGateway.RetrieveDevelopers();
-
-                response.First().FirstName.Should().Be("Wen Ting");
-            }
-
-            [Test]
-            public void CanGetDeveloper2()
-            {
-                SetUpUsersApiEndpoint(
-                    "456",
-                    "Tingker",
-                    "Bell",
-                    "tingkerbell@email.com"
-                );
-
-                var response = _harvestGateway.RetrieveDevelopers();
-
-                response.First().FirstName.Should().Be("Tingker");
-            }
-
-            [Test]
-            public void CanGetDeveloperWithAuthentication()
-            {
-                SetUpUsersApiEndpoint(
-                    "789",
-                    "Tingky",
-                    "Winky",
-                    "tingkywinky@email.com"
-                );
+                SetUpUsersApiEndpoint("1234567", "Wen Ting", "Wang","wenting@ting.com");
 
                 _harvestGateway.RetrieveDevelopers();
                 
-                _harvestApi.ReceivedRequests.First().Headers["Authorization"].Should().Be("Bearer " + Token);
+                _harvestApi.ReceivedRequests.First().Headers["Authorization"].Should().Be($"Bearer {Token}");
+            }
+
+            [Test]
+            [TestCase("2345678", "Tingky", "Winky", "tingkywinky@ting.com")]
+            [TestCase("3456789", "Tingker", "Bell", "tingkerbell@ting.com")]
+            [TestCase("4567891", "Ting", "Tings", "tingtings@ting.com")]
+            public void CanGetADeveloper(string id, string firstName, string lastName, string email)
+            {
+                SetUpUsersApiEndpoint(id, firstName, lastName, email);
+
+                var response = _harvestGateway.RetrieveDevelopers();
+
+                response.First().FirstName.Should().Be(firstName);
             }
         }
 
         [TestFixture]
         public class CanRequestTimeSheets
         {
+            private const string ApiTimeSheetPath = "api/v2/time_entries";
             private FluentSimulator _harvestApi;
             private HarvestGateway _harvestGateway;
             
@@ -106,41 +86,53 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 _harvestApi.Stop();
             }
             
-            private void SetUpTimeSheetApiEndpoint(string jsonFilePath, string dateFrom, string dateTo)
+            private void SetUpTimeSheetApiEndpoint(string dateFrom, string dateTo)
             {
                 var json = File.ReadAllText(
                     Path.Combine(
                         AppDomain.CurrentDomain.BaseDirectory,
-                        jsonFilePath
+                        "../../../Gateway/HarvestTimeEntriesApiEndpoint.json"
                     )
                 );
-                var address = "/api/v2/time_entries";
-                _harvestApi.Get(address).WithParameter("from", dateFrom).WithParameter("to", dateTo).Responds(json);
+
+                _harvestApi.Get($"/{ApiTimeSheetPath}")
+                    .WithParameter("from", dateFrom)
+                    .WithParameter("to", dateTo)
+                    .Responds(json);
+                
                 _harvestApi.Start();
             }
-
+            
             [Test]
-            public void CanGetATimeSheet()
+            [TestCase("08", "12")]
+            [TestCase("14", "19")]
+            [TestCase("01", "05")]
+            public void CanRequestTimeSheetsUsingAStartingAndEndingDate(string dayFrom, string dayTo)
             {
-                SetUpTimeSheetApiEndpoint("../../../Gateway/HarvestTimeEntriesApiEndpoint.json", "2019-04-08", "2019-04-12");
+                SetUpTimeSheetApiEndpoint($"2019-04-{dayFrom}", $"2019-04-{dayTo}");
 
                 var dateFrom = new DateTimeOffset(
-                    new DateTime(2019, 04, 08)
+                    new DateTime(2019, 04, int.Parse(dayFrom))
                 );
-                
+               
                 var dateTo = new DateTimeOffset(
-                    new DateTime(2019, 04, 12)
+                    new DateTime(2019, 04, int.Parse(dayTo))
                 );
                 
-                var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
+                _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
 
-                response.First().UserId.Should().Be(1782975);
+                _harvestApi.ReceivedRequests.First().Url.Should().Be(
+                    $"{Address}{ApiTimeSheetPath}?from=2019-04-{dayFrom}&to=2019-04-{dayTo}"
+                );
             }
 
             [Test]
-            public void CanGetAnotherTimeSheet()
+            [TestCase(456709345)]
+            [TestCase(636709355)]
+            [TestCase(636709356)]
+            public void CanGetATimeSheet(int expectedId)
             {
-                SetUpTimeSheetApiEndpoint("../../../Gateway/HarvestTimeEntriesApiEndpoint.json", "2019-04-08", "2019-04-12");
+                SetUpTimeSheetApiEndpoint("2019-04-08", "2019-04-12");
 
                 var dateFrom = new DateTimeOffset(
                     new DateTime(2019, 04, 08)
@@ -152,13 +144,13 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 
                 var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
 
-                response.Any(entry => entry.UserId == 1782974).Should().Be(true);
+                response.Any(entry => entry.Id == expectedId).Should().BeTrue();
             }
 
             [Test]
             public void CanGetAllTimeSheetProperties()
             {
-                SetUpTimeSheetApiEndpoint("../../../Gateway/HarvestTimeEntriesApiEndpoint.json", "2019-04-08", "2019-04-12");
+                SetUpTimeSheetApiEndpoint("2019-04-08", "2019-04-12");
 
                 var dateFrom = new DateTimeOffset(
                     new DateTime(2019, 04, 08)
@@ -168,28 +160,11 @@ namespace CryptoTechReminderSystem.Test.Gateway
                     new DateTime(2019, 04, 12)
                 );
                 
-                var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo).First();
-                response.Id.Should().Be(456709345);
-                response.UserId.Should().Be(1782975);
-                response.Hours.Should().Be(8.0);
-            }
-            
-            [Test]
-            public void CanRequestTimesheetsUsingAStartingAndEndingDate()
-            {
-                SetUpTimeSheetApiEndpoint("../../../Gateway/HarvestTimeEntriesApiEndpoint.json", "2019-04-08", "2019-04-12");
-
-                var dateFrom = new DateTimeOffset(
-                    new DateTime(2019, 04, 08)
-                );
+                var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
                 
-                var dateTo = new DateTimeOffset(
-                    new DateTime(2019, 04, 12)
-                );
-                
-                _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
-
-                _harvestApi.ReceivedRequests.First().Url.Should().Be(Address + "api/v2/time_entries?from=2019-04-08&to=2019-04-12");
+                response.First().Id.Should().Be(456709345);
+                response.First().UserId.Should().Be(1782975);
+                response.First().Hours.Should().Be(8.0);
             }
         }
     }

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -122,7 +122,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanGetATimeSheet()
             {
-                var response = _harvestGateway.RetrieveTimeSheets();
+                var response = _harvestGateway.RetrieveTimeSheets(new DateTimeOffset(), new DateTimeOffset());
 
                 response.First().UserId.Should().Be(1782975);
             }
@@ -130,7 +130,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanGetAnotherTimeSheet()
             {
-                var response = _harvestGateway.RetrieveTimeSheets();
+                var response = _harvestGateway.RetrieveTimeSheets(new DateTimeOffset(), new DateTimeOffset());
 
                 response.Any(entry => entry.UserId == 1782974).Should().Be(true);
             }
@@ -138,7 +138,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             [Test]
             public void CanGetAllTimeSheetProperties()
             {
-                var response = _harvestGateway.RetrieveTimeSheets().First();
+                var response = _harvestGateway.RetrieveTimeSheets(new DateTimeOffset(), new DateTimeOffset()).First();
                 response.Id.Should().Be(456709345);
                 response.UserId.Should().Be(1782975);
                 response.Hours.Should().Be(8.0);

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -72,12 +72,20 @@ namespace CryptoTechReminderSystem.Test.Gateway
             private const string ApiTimeSheetPath = "api/v2/time_entries";
             private FluentSimulator _harvestApi;
             private HarvestGateway _harvestGateway;
-            
+            private DateTimeOffset _defaultDateFrom;
+            private DateTimeOffset _defaultDateTo;
+
             [SetUp]
             public void Setup()
             {
                 _harvestApi = new FluentSimulator(Address);
                 _harvestGateway = new HarvestGateway(Address, Token);
+                _defaultDateFrom = new DateTimeOffset(
+                    new DateTime(2019, 04, 08)
+                );
+                _defaultDateTo = new DateTimeOffset(
+                    new DateTime(2019, 04, 12)
+                );
             }
 
             [TearDown]
@@ -133,15 +141,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             {
                 SetUpTimeSheetApiEndpoint("2019-04-08", "2019-04-12");
 
-                var dateFrom = new DateTimeOffset(
-                    new DateTime(2019, 04, 08)
-                );
-                
-                var dateTo = new DateTimeOffset(
-                    new DateTime(2019, 04, 12)
-                );
-                
-                var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
+                var response = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
 
                 response.Any(entry => entry.UserId == expectedUserId).Should().BeTrue();
             }
@@ -151,15 +151,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             {
                 SetUpTimeSheetApiEndpoint("2019-04-08", "2019-04-12");
 
-                var dateFrom = new DateTimeOffset(
-                    new DateTime(2019, 04, 08)
-                );
-                
-                var dateTo = new DateTimeOffset(
-                    new DateTime(2019, 04, 12)
-                );
-                
-                var response = _harvestGateway.RetrieveTimeSheets(dateFrom, dateTo);
+                var response = _harvestGateway.RetrieveTimeSheets(_defaultDateFrom, _defaultDateTo);
                 
                 response.First().Id.Should().Be(456709345);
                 response.First().UserId.Should().Be(1782975);

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -12,6 +12,15 @@ namespace CryptoTechReminderSystem.Test.UseCase
 {
     public class GetLateDevelopersTests
     {
+        private HarvestGatewaySpy _harvestGatewaySpy;
+        private SlackGatewaySpy _slackGatewaySpy;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _harvestGatewaySpy = new HarvestGatewaySpy();
+            _slackGatewaySpy = new SlackGatewaySpy();
+        }
         private class HarvestGatewayStub : IHarvestDeveloperRetriever, ITimeSheetRetriever
         {
             public HarvestDeveloper[] Developers { private get; set; }
@@ -81,59 +90,63 @@ namespace CryptoTechReminderSystem.Test.UseCase
         [Test]
         public void CanGetHarvestDevelopers()
         {
-            var harvestGatewaySpy = new HarvestGatewaySpy();
-            var slackGatewaySpy = new SlackGatewaySpy();
+            
             var clock = new ClockStub(
                 new DateTimeOffset(
                     new DateTime(2019, 03, 01, 10, 30, 0)
                 )
             );
             
-            var getDevelopers = new GetLateDevelopers(slackGatewaySpy, harvestGatewaySpy, harvestGatewaySpy, clock);
+            var getDevelopers = new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
             getDevelopers.Execute();
             
-            harvestGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+            _harvestGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
         }
         
         
         [Test]
         public void CanGetSlackDevelopers()
         {
-            var harvestGatewaySpy = new HarvestGatewaySpy();
-            var slackGatewaySpy = new SlackGatewaySpy();
             var clock = new ClockStub(
                 new DateTimeOffset(
                     new DateTime(2019, 03, 01, 10, 30, 0)
                 )
             );
             
-            var getDevelopers = new GetLateDevelopers(slackGatewaySpy, harvestGatewaySpy, harvestGatewaySpy, clock);
+            var getDevelopers = new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
             getDevelopers.Execute();
 
-            slackGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+            _slackGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
         }
 
         [TestFixture]
         public class CanGetTimeSheets
         {
+            private HarvestGatewaySpy _harvestGatewaySpy;
+            private SlackGatewayStub _slackGatewayStub;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _harvestGatewaySpy = new HarvestGatewaySpy();
+                _slackGatewayStub = new SlackGatewayStub();
+            }
             [Test]
             public void CanRetrieveTimeSheets()
             {
-                var harvestGatewaySpy = new HarvestGatewaySpy();
-                var slackGatewayStub = new SlackGatewayStub();
                 var clock = new ClockStub(
                     new DateTimeOffset(
                         new DateTime(2019, 03, 01, 10, 30, 0)
                     )
                 );
             
-                var getDevelopers = new GetLateDevelopers(slackGatewayStub, harvestGatewaySpy, harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
-                harvestGatewaySpy.IsRetrieveTimeSheetsCalled.Should().BeTrue();
+                _harvestGatewaySpy.IsRetrieveTimeSheetsCalled.Should().BeTrue();
             }
             
             [Test]
@@ -144,19 +157,17 @@ namespace CryptoTechReminderSystem.Test.UseCase
             [TestCase(15)]
             public void CanRetrieveTimeSheetsWithStartingDate(int day)
             {
-                var harvestGatewaySpy = new HarvestGatewaySpy();
-                var slackGatewayStub = new SlackGatewayStub();
                 var clock = new ClockStub(
                     new DateTimeOffset(
                         new DateTime(2019, 04, day)
                     )
                 );
             
-                var getDevelopers = new GetLateDevelopers(slackGatewayStub, harvestGatewaySpy, harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
-                harvestGatewaySpy.RetrieveTimeSheetsArguments[0].Should().Be(
+                _harvestGatewaySpy.RetrieveTimeSheetsArguments[0].Should().Be(
                     new DateTimeOffset(
                         new DateTime(2019, 04, 15)
                     )
@@ -171,19 +182,17 @@ namespace CryptoTechReminderSystem.Test.UseCase
             [TestCase(12)]
             public void CanRetrieveTimeSheetsWithEndingDate(int day)
             {
-                var harvestGatewaySpy = new HarvestGatewaySpy();
-                var slackGatewayStub = new SlackGatewayStub();
                 var clock = new ClockStub(
                     new DateTimeOffset(
                         new DateTime(2019, 04, day)
                     )
                 );
             
-                var getDevelopers = new GetLateDevelopers(slackGatewayStub, harvestGatewaySpy, harvestGatewaySpy, clock);
+                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewaySpy, _harvestGatewaySpy, clock);
             
                 getDevelopers.Execute();
 
-                harvestGatewaySpy.RetrieveTimeSheetsArguments[1].Should().Be(
+                _harvestGatewaySpy.RetrieveTimeSheetsArguments[1].Should().Be(
                     new DateTimeOffset(
                         new DateTime(2019, 04, 12)
                     )

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -12,8 +12,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
 {
     public class GetLateDevelopersTests
     {
-        private HarvestGatewaySpy _harvestGatewaySpy;
-        private SlackGatewaySpy _slackGatewaySpy;
+        private static HarvestGatewaySpy _harvestGatewaySpy;
+        private static SlackGatewaySpy _slackGatewaySpy;
 
         [SetUp]
         public void SetUp()
@@ -86,45 +86,48 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 return new List<SlackDeveloper>();
             }
         }
-        
-        [Test]
-        public void CanGetHarvestDevelopers()
-        {
-            
-            var clock = new ClockStub(
-                new DateTimeOffset(
-                    new DateTime(2019, 03, 01, 10, 30, 0)
-                )
-            );
-            
-            var getDevelopers = new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, clock);
-            
-            getDevelopers.Execute();
-            
-            _harvestGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
-        }
-        
-        
-        [Test]
-        public void CanGetSlackDevelopers()
-        {
-            var clock = new ClockStub(
-                new DateTimeOffset(
-                    new DateTime(2019, 03, 01, 10, 30, 0)
-                )
-            );
-            
-            var getDevelopers = new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, clock);
-            
-            getDevelopers.Execute();
 
-            _slackGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+        [TestFixture]
+        public class CanGetDevelopers
+        {
+            private ClockStub _clock;
+            private GetLateDevelopers _getDevelopers;
+            
+            [SetUp]
+            public void SetUp()
+            {
+                _harvestGatewaySpy = new HarvestGatewaySpy();
+                _slackGatewaySpy = new SlackGatewaySpy();
+                _clock = new ClockStub(
+                    new DateTimeOffset(
+                        new DateTime(2019, 03, 01, 10, 30, 0)
+                    )
+                );
+
+                _getDevelopers =
+                    new GetLateDevelopers(_slackGatewaySpy, _harvestGatewaySpy, _harvestGatewaySpy, _clock);
+            }
+            
+            [Test]
+            public void CanGetHarvestDevelopers()
+            {
+                _getDevelopers.Execute();
+
+                _harvestGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+            }
+
+            [Test]
+            public void CanGetSlackDevelopers()
+            {
+                _getDevelopers.Execute();
+
+                _slackGatewaySpy.IsRetrieveDevelopersCalled.Should().BeTrue();
+            }
         }
 
         [TestFixture]
         public class CanGetTimeSheets
         {
-            private HarvestGatewaySpy _harvestGatewaySpy;
             private SlackGatewayStub _slackGatewayStub;
 
             [SetUp]
@@ -133,6 +136,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 _harvestGatewaySpy = new HarvestGatewaySpy();
                 _slackGatewayStub = new SlackGatewayStub();
             }
+            
             [Test]
             public void CanRetrieveTimeSheets()
             {

--- a/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
+++ b/CryptoTechReminderSystem.Test/UseCase/GetLateDevelopersTests.cs
@@ -14,20 +14,18 @@ namespace CryptoTechReminderSystem.Test.UseCase
     {
         private class HarvestGatewayStub : IHarvestDeveloperRetriever, ITimeSheetRetriever
         {
-            public HarvestDeveloper[] Developers { get; set; }
+            public HarvestDeveloper[] Developers { private get; set; }
             
-            public TimeSheet[] TimeSheets { get; set; }
+            public TimeSheet[] TimeSheets { private get; set; }
             
             public IList<HarvestDeveloper> RetrieveDevelopers()
             {
-                IList<HarvestDeveloper> result = Developers;
-                return result;
+                return Developers;
             }
 
             public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)
             {
-                IList<TimeSheet> result = TimeSheets;
-                return result;
+                return TimeSheets;
             }
         }
 
@@ -40,9 +38,8 @@ namespace CryptoTechReminderSystem.Test.UseCase
             public IList<HarvestDeveloper> RetrieveDevelopers()
             {
                 IsRetrieveDevelopersCalled = true;
-                IList<HarvestDeveloper> result = new List<HarvestDeveloper>();
               
-                return result;
+                return new List<HarvestDeveloper>();
             }
 
             public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)
@@ -65,8 +62,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
 
             public IList<SlackDeveloper> RetrieveDevelopers()
             {
-                IList<SlackDeveloper> result = Developers;
-                return result;
+                return Developers;
             }
         }
 
@@ -77,6 +73,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             public IList<SlackDeveloper> RetrieveDevelopers()
             {
                 IsRetrieveDevelopersCalled = true;
+                
                 return new List<SlackDeveloper>();
             }
         }
@@ -91,6 +88,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new DateTime(2019, 03, 01, 10, 30, 0)
                 )
             );
+            
             var getDevelopers = new GetLateDevelopers(slackGatewaySpy, harvestGatewaySpy, harvestGatewaySpy, clock);
             
             getDevelopers.Execute();
@@ -109,6 +107,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                     new DateTime(2019, 03, 01, 10, 30, 0)
                 )
             );
+            
             var getDevelopers = new GetLateDevelopers(slackGatewaySpy, harvestGatewaySpy, harvestGatewaySpy, clock);
             
             getDevelopers.Execute();
@@ -117,10 +116,10 @@ namespace CryptoTechReminderSystem.Test.UseCase
         }
 
         [TestFixture]
-        public class CanGetTimesheets
+        public class CanGetTimeSheets
         {
             [Test]
-            public void CanRetrieveTimesheets()
+            public void CanRetrieveTimeSheets()
             {
                 var harvestGatewaySpy = new HarvestGatewaySpy();
                 var slackGatewayStub = new SlackGatewayStub();
@@ -143,7 +142,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             [TestCase(17)]
             [TestCase(16)]
             [TestCase(15)]
-            public void CanRetrieveTimesheetsWithStartingDate(int day)
+            public void CanRetrieveTimeSheetsWithStartingDate(int day)
             {
                 var harvestGatewaySpy = new HarvestGatewaySpy();
                 var slackGatewayStub = new SlackGatewayStub();
@@ -170,7 +169,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
             [TestCase(10)]
             [TestCase(11)]
             [TestCase(12)]
-            public void CanRetrieveTimesheetsWithEndingDate(int day)
+            public void CanRetrieveTimeSheetsWithEndingDate(int day)
             {
                 var harvestGatewaySpy = new HarvestGatewaySpy();
                 var slackGatewayStub = new SlackGatewayStub();
@@ -241,10 +240,12 @@ namespace CryptoTechReminderSystem.Test.UseCase
             }
             
             [Test]
-            public void CanGetLateDeveloper()
+            [TestCase(1337, "U9999")]
+            [TestCase(123, "U8723")]
+            public void CanGetLateADeveloper(int harvestUserId, string slackUserId)
             {
                 _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
-                    new TimeSheet { Hours = 7, UserId = 1337 }, 5
+                    new TimeSheet { Hours = 7, UserId = harvestUserId }, 5
                 ).ToArray();
                 
                 var clock = new ClockStub(
@@ -257,27 +258,7 @@ namespace CryptoTechReminderSystem.Test.UseCase
                 
                 var response = getDevelopers.Execute();
          
-                response.Developers.First().Should().Be("U9999");
-            }
-            
-            [Test]
-            public void CanGetAnotherLateDeveloper()
-            {                
-                _harvestGatewayStub.TimeSheets = Enumerable.Repeat(
-                    new TimeSheet { Hours = 7, UserId = 123 }, 5
-                ).ToArray();
-                
-                var clock = new ClockStub(
-                    new DateTimeOffset(
-                        new DateTime(2019, 03, 01, 10, 30, 0)
-                    )
-                );
-
-                var getDevelopers = new GetLateDevelopers(_slackGatewayStub, _harvestGatewayStub, _harvestGatewayStub, clock);
-                
-                var response = getDevelopers.Execute();
-              
-                response.Developers.First().Should().Be("U8723");
+                response.Developers.First().Should().Be(slackUserId);
             }
         }
     }

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -42,7 +42,7 @@ namespace CryptoTechReminderSystem.Gateway
             ).ToList(); 
         }
 
-        public IList<TimeSheet> RetrieveTimeSheets()
+        public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
  

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -22,6 +22,7 @@ namespace CryptoTechReminderSystem.Gateway
         
         private async Task<JObject> GetApiResponse(string address)
         {
+            Console.WriteLine(address);
             var response = await _client.GetAsync(address);
             return JObject.Parse(await response.Content.ReadAsStringAsync());
         }
@@ -45,8 +46,12 @@ namespace CryptoTechReminderSystem.Gateway
         public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
- 
-            var apiResponse = GetApiResponse("/api/v2/time_entries").Result;
+            
+            var dateFromFmt = dateFrom.ToString("yyyy-MM-dd");
+            var dateToFmt = dateTo.ToString("yyyy-MM-dd");
+            var address = $"/api/v2/time_entries?from={dateFromFmt}&to={dateToFmt}";
+            
+            var apiResponse = GetApiResponse(address).Result;
             var timeSheets = apiResponse["time_entries"];
             return timeSheets.Select(timeSheet => new TimeSheet
                 {

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -12,8 +12,13 @@ namespace CryptoTechReminderSystem.Gateway
     public class HarvestGateway : IHarvestDeveloperRetriever, ITimeSheetRetriever
     {
         private readonly HttpClient _client;
-        private string _token;
+        private readonly string _token;
 
+        private static string ToHarvestApiString(DateTimeOffset date)
+        {
+            return date.ToString("yyyy-MM-dd");
+        }
+        
         public HarvestGateway(string address, string token)
         {
             _client = new HttpClient { BaseAddress = new Uri(address) };
@@ -45,9 +50,9 @@ namespace CryptoTechReminderSystem.Gateway
         public IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo)
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
-            
-            var dateFromFmt = dateFrom.ToString("yyyy-MM-dd");
-            var dateToFmt = dateTo.ToString("yyyy-MM-dd");
+
+            var dateFromFmt = ToHarvestApiString(dateFrom);
+            var dateToFmt = ToHarvestApiString(dateTo);
             var address = $"/api/v2/time_entries?from={dateFromFmt}&to={dateToFmt}";
             
             var apiResponse = GetApiResponse(address).Result;

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -51,9 +51,7 @@ namespace CryptoTechReminderSystem.Gateway
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
-            var dateFromFmt = ToHarvestApiString(dateFrom);
-            var dateToFmt = ToHarvestApiString(dateTo);
-            var address = $"/api/v2/time_entries?from={dateFromFmt}&to={dateToFmt}";
+            var address = $"/api/v2/time_entries?from={ToHarvestApiString(dateFrom)}&to={ToHarvestApiString(dateTo)}";
             
             var apiResponse = GetApiResponse(address).Result;
             var timeSheets = apiResponse["time_entries"];
@@ -62,7 +60,7 @@ namespace CryptoTechReminderSystem.Gateway
                     Id = (int)timeSheet["id"],
                     TimeSheetDate = timeSheet["spent_date"].ToString(),
                     UserId = (int)timeSheet["user"]["id"],
-                    Hours = (float)timeSheet["hours"],
+                    Hours = (float)timeSheet["hours"]
                 }
             ).ToList(); 
         }

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -22,7 +22,6 @@ namespace CryptoTechReminderSystem.Gateway
         
         private async Task<JObject> GetApiResponse(string address)
         {
-            Console.WriteLine(address);
             var response = await _client.GetAsync(address);
             return JObject.Parse(await response.Content.ReadAsStringAsync());
         }

--- a/CryptoTechReminderSystem/Gateway/ITimeSheetRetriever.cs
+++ b/CryptoTechReminderSystem/Gateway/ITimeSheetRetriever.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CryptoTechReminderSystem.DomainObject;
 
@@ -5,6 +6,6 @@ namespace CryptoTechReminderSystem.Gateway
 {
     public interface ITimeSheetRetriever
     {
-        IList<TimeSheet> RetrieveTimeSheets();
+        IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo);
     }
 }

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -20,23 +20,6 @@ namespace CryptoTechReminderSystem.UseCase
             _slackDeveloperRetriever = slackDeveloperRetriever;
             _clock = clock;
         }
-
-        private DateTimeOffset GetStartingDate(DateTimeOffset currentDateTime)
-        {
-            switch (currentDateTime.DayOfWeek)
-            {
-                case DayOfWeek.Friday:
-                    return currentDateTime.AddDays(-4);
-                case DayOfWeek.Thursday:
-                    return currentDateTime.AddDays(-3);
-                case DayOfWeek.Wednesday:
-                    return currentDateTime.AddDays(-2);
-                case DayOfWeek.Tuesday:
-                    return currentDateTime.AddDays(-1);
-                default:
-                    return currentDateTime;
-            }
-        }
         
         public GetLateDevelopersResponse Execute()
         {
@@ -63,22 +46,17 @@ namespace CryptoTechReminderSystem.UseCase
             }
             return getLateDevelopersResponse;
         }
-
-        private DateTimeOffset GetEndingDate(DateTimeOffset currentDateTime)
+        
+        private static DateTimeOffset GetStartingDate(DateTimeOffset currentDateTime)
         {
-            switch (currentDateTime.DayOfWeek)
-            {
-                case DayOfWeek.Monday:
-                    return currentDateTime.AddDays(4);
-                case DayOfWeek.Tuesday:
-                    return currentDateTime.AddDays(3);
-                case DayOfWeek.Wednesday:
-                    return currentDateTime.AddDays(2);
-                case DayOfWeek.Thursday:
-                    return currentDateTime.AddDays(1);
-                default:
-                    return currentDateTime;
-            }
+            var diff = (7 + (currentDateTime.DayOfWeek - DayOfWeek.Monday)) % 7;
+            return currentDateTime.AddDays(-diff);
+        }
+
+        private static DateTimeOffset GetEndingDate(DateTimeOffset currentDateTime)
+        {
+            var diff = (7 + (DayOfWeek.Friday - currentDateTime.DayOfWeek)) % 7;
+            return currentDateTime.AddDays(diff);
         }
     }
 }

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -11,7 +11,7 @@ namespace CryptoTechReminderSystem.UseCase
         private readonly IHarvestDeveloperRetriever _harvestDeveloperRetriever;
         private readonly ITimeSheetRetriever _harvestTimeSheetRetriever;
         private readonly ISlackDeveloperRetriever _slackDeveloperRetriever;
-        private IClock _clock;
+        private readonly IClock _clock;
 
         public GetLateDevelopers(ISlackDeveloperRetriever slackDeveloperRetriever, IHarvestDeveloperRetriever harvestDeveloperRetriever, ITimeSheetRetriever harvestTimeSheetRetriever, IClock clock)
         {
@@ -26,8 +26,8 @@ namespace CryptoTechReminderSystem.UseCase
             var harvestGetDevelopersResponse = _harvestDeveloperRetriever.RetrieveDevelopers();
             var slackGetDevelopersResponse = _slackDeveloperRetriever.RetrieveDevelopers();
 
-            DateTimeOffset dateFrom = GetStartingDate(_clock.Now());
-            DateTimeOffset dateTo = GetEndingDate(_clock.Now());
+            var dateFrom = GetStartingDate(_clock.Now());
+            var dateTo = GetEndingDate(_clock.Now());
             
             var harvestGetTimesheetsResponse = _harvestTimeSheetRetriever.RetrieveTimeSheets(dateFrom, dateTo);
             var getLateDevelopersResponse = new GetLateDevelopersResponse

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using CryptoTechReminderSystem.Boundary;
@@ -10,19 +11,42 @@ namespace CryptoTechReminderSystem.UseCase
         private readonly IHarvestDeveloperRetriever _harvestDeveloperRetriever;
         private readonly ITimeSheetRetriever _harvestTimeSheetRetriever;
         private readonly ISlackDeveloperRetriever _slackDeveloperRetriever;
+        private IClock _clock;
 
-        public GetLateDevelopers(ISlackDeveloperRetriever slackDeveloperRetriever, IHarvestDeveloperRetriever harvestDeveloperRetriever, ITimeSheetRetriever harvestTimeSheetRetriever)
+        public GetLateDevelopers(ISlackDeveloperRetriever slackDeveloperRetriever, IHarvestDeveloperRetriever harvestDeveloperRetriever, ITimeSheetRetriever harvestTimeSheetRetriever, IClock clock)
         {
             _harvestDeveloperRetriever = harvestDeveloperRetriever;
             _harvestTimeSheetRetriever = harvestTimeSheetRetriever;
             _slackDeveloperRetriever = slackDeveloperRetriever;
+            _clock = clock;
         }
 
+        private DateTimeOffset GetStartingDate(DateTimeOffset currentDateTime)
+        {
+            switch (currentDateTime.DayOfWeek)
+            {
+                case DayOfWeek.Friday:
+                    return currentDateTime.AddDays(-4);
+                case DayOfWeek.Thursday:
+                    return currentDateTime.AddDays(-3);
+                case DayOfWeek.Wednesday:
+                    return currentDateTime.AddDays(-2);
+                case DayOfWeek.Tuesday:
+                    return currentDateTime.AddDays(-1);
+                default:
+                    return currentDateTime;
+            }
+        }
+        
         public GetLateDevelopersResponse Execute()
         {
             var harvestGetDevelopersResponse = _harvestDeveloperRetriever.RetrieveDevelopers();
             var slackGetDevelopersResponse = _slackDeveloperRetriever.RetrieveDevelopers();
-            var harvestGetTimesheetsResponse = _harvestTimeSheetRetriever.RetrieveTimeSheets();
+
+            DateTimeOffset dateFrom = GetStartingDate(_clock.Now());
+            DateTimeOffset dateTo = GetEndingDate(_clock.Now());
+            
+            var harvestGetTimesheetsResponse = _harvestTimeSheetRetriever.RetrieveTimeSheets(dateFrom, dateTo);
             var getLateDevelopersResponse = new GetLateDevelopersResponse
             {
                 Developers = new List<string>()
@@ -38,6 +62,23 @@ namespace CryptoTechReminderSystem.UseCase
                 }
             }
             return getLateDevelopersResponse;
+        }
+
+        private DateTimeOffset GetEndingDate(DateTimeOffset currentDateTime)
+        {
+            switch (currentDateTime.DayOfWeek)
+            {
+                case DayOfWeek.Monday:
+                    return currentDateTime.AddDays(4);
+                case DayOfWeek.Tuesday:
+                    return currentDateTime.AddDays(3);
+                case DayOfWeek.Wednesday:
+                    return currentDateTime.AddDays(2);
+                case DayOfWeek.Thursday:
+                    return currentDateTime.AddDays(1);
+                default:
+                    return currentDateTime;
+            }
         }
     }
 }

--- a/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
+++ b/CryptoTechReminderSystem/UseCase/GetLateDevelopers.cs
@@ -49,14 +49,14 @@ namespace CryptoTechReminderSystem.UseCase
         
         private static DateTimeOffset GetStartingDate(DateTimeOffset currentDateTime)
         {
-            var diff = (7 + (currentDateTime.DayOfWeek - DayOfWeek.Monday)) % 7;
-            return currentDateTime.AddDays(-diff);
+            var daysFromMonday = (7 + (currentDateTime.DayOfWeek - DayOfWeek.Monday)) % 7;
+            return currentDateTime.AddDays(-daysFromMonday);
         }
 
         private static DateTimeOffset GetEndingDate(DateTimeOffset currentDateTime)
         {
-            var diff = (7 + (DayOfWeek.Friday - currentDateTime.DayOfWeek)) % 7;
-            return currentDateTime.AddDays(diff);
+            var daysToFriday = (7 + (DayOfWeek.Friday - currentDateTime.DayOfWeek)) % 7;
+            return currentDateTime.AddDays(daysToFriday);
         }
     }
 }


### PR DESCRIPTION
We've made a number of changes:
- `GetLateDevelopers` use case takes in a clock in order to calculate the starting and ending date of the week for retrieving timesheets to pass into the Harvest gateway
- `ITimeSheetRetriever#RetrieveTimeSheets` now has two parameters: `IList<TimeSheet> RetrieveTimeSheets(DateTimeOffset dateFrom, DateTimeOffset dateTo);`
- The `HarvestGateway#RetrieveTimeSheets` formats these DateTimeOffsets into strings for the `GET` request parameters for retrieving timesheets
- Refactor the unit tests as well