### PR TITLE
Add Harvest account ID as request header to gateway

### DIFF
--- a/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
+++ b/CryptoTechReminderSystem.AcceptanceTest/CryptoTechReminderSystemTests.cs
@@ -44,7 +44,7 @@ namespace CryptoTechReminderSystem.AcceptanceTest
             _slackApi = new FluentSimulator(SlackApiAddress);
             _slackGateway = new SlackGateway(SlackApiAddress,"xxxx-xxxxxxxxx-xxxx");
             _harvestApi = new FluentSimulator(HarvestApiAddress);
-            _harvestGateway = new HarvestGateway(HarvestApiAddress, "xxxx-xxxxxxxxx-xxxx");
+            _harvestGateway = new HarvestGateway(HarvestApiAddress, "xxxx-xxxxxxxxx-xxxx", "234567");
             _sendReminder = new SendReminder(_slackGateway);
             
             var slackGetUsersResponse = File.ReadAllText(

--- a/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
+++ b/CryptoTechReminderSystem.Test/Gateway/HarvestGatewayTests.cs
@@ -13,6 +13,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
     {
         private const string Address = "http://localhost:8050/";
         private const string Token = "xxxx-xxxxxxxxx-xxxx";
+        private const string HarvestAccountId = "123456";
 
         [TestFixture]
         public class CanRequestDevelopers
@@ -25,7 +26,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             {
                 _harvestApi = new FluentSimulator(Address);
                 _harvestApi.Start();
-                _harvestGateway = new HarvestGateway(Address, Token);
+                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId);
             }
 
             [TearDown]
@@ -50,6 +51,16 @@ namespace CryptoTechReminderSystem.Test.Gateway
                 _harvestGateway.RetrieveDevelopers();
                 
                 _harvestApi.ReceivedRequests.First().Headers["Authorization"].Should().Be($"Bearer {Token}");
+            }
+            
+            [Test]
+            public void CanGetDevelopersWithHarvestAccountId()
+            {
+                SetUpUsersApiEndpoint("1234567", "Wen Ting", "Wang","wenting@ting.com");
+
+                _harvestGateway.RetrieveDevelopers();
+                
+                _harvestApi.ReceivedRequests.First().Headers["Harvest-Account-Id"].Should().Be(HarvestAccountId);
             }
 
             [Test]
@@ -79,7 +90,7 @@ namespace CryptoTechReminderSystem.Test.Gateway
             public void Setup()
             {
                 _harvestApi = new FluentSimulator(Address);
-                _harvestGateway = new HarvestGateway(Address, Token);
+                _harvestGateway = new HarvestGateway(Address, Token, HarvestAccountId);
                 _defaultDateFrom = new DateTimeOffset(
                     new DateTime(2019, 04, 08)
                 );

--- a/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
+++ b/CryptoTechReminderSystem/Gateway/HarvestGateway.cs
@@ -13,16 +13,18 @@ namespace CryptoTechReminderSystem.Gateway
     {
         private readonly HttpClient _client;
         private readonly string _token;
+        private readonly string _accountId;
 
         private static string ToHarvestApiString(DateTimeOffset date)
         {
             return date.ToString("yyyy-MM-dd");
         }
         
-        public HarvestGateway(string address, string token)
+        public HarvestGateway(string address, string token, string accountId)
         {
             _client = new HttpClient { BaseAddress = new Uri(address) };
             _token = token;
+            _accountId = accountId;
         }
         
         private async Task<JObject> GetApiResponse(string address)
@@ -34,6 +36,7 @@ namespace CryptoTechReminderSystem.Gateway
         public IList<HarvestDeveloper> RetrieveDevelopers()
         {
             _client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+            _client.DefaultRequestHeaders.Add("Harvest-Account-Id",_accountId);
  
             var apiResponse = GetApiResponse("/api/v2/users").Result;
             var users = apiResponse["users"];


### PR DESCRIPTION
Harvest API requires an account ID so we have implemented this in the gateway.